### PR TITLE
add file command

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/GitLink.xml
+++ b/.idea/GitLink.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="uk.co.ben_gibson.git.link.SettingsState">
+    <option name="host" value="72037fcc-cb9c-4c22-960a-ffe73fd5e229" />
+  </component>
+</project>

--- a/.idea/gutenberg.iml
+++ b/.idea/gutenberg.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="GOOGLE" />
+    <option name="myDocStringFormat" value="Google" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.10" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/gutenberg.iml" filepath="$PROJECT_DIR$/.idea/gutenberg.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/gutenberg.py
+++ b/gutenberg.py
@@ -819,12 +819,12 @@ def cmd_text(argv):
 
 def cmd_file(argv):
    for author, title, blob in Gutenberg().file(argv[0]):
-      normalized_author = slugify(author)
-      normalized_title = slugify(title)
+      normalized_author = slugify(author)[:32]
+      normalized_title = slugify(title)[:48]
       if not os.path.exists(normalized_author):
          print(f"create directory: {normalized_author}")
          os.makedirs(normalized_author)
-      target = os.path.join(normalized_author, normalized_title)
+      target = os.path.join(normalized_author, normalized_title) + ".txt"
       if not os.path.exists(target):
          print(f"create file: {target}")
          with open(target, "w") as f:

--- a/gutenberg.py
+++ b/gutenberg.py
@@ -821,16 +821,13 @@ def cmd_file(argv):
    for author, title, blob in Gutenberg().file(argv[0]):
       normalized_author = slugify(author)[:32]
       normalized_title = slugify(title)[:48]
-      if not os.path.exists(normalized_author):
-         print(f"create directory: {normalized_author}")
-         os.makedirs(normalized_author)
-      target = os.path.join(normalized_author, normalized_title) + ".txt"
-      if not os.path.exists(target):
-         print(f"create file: {target}")
+      target = f"{normalized_author}_{normalized_title}.txt"
+      if os.path.exists(target):
+         print(f"SKIPPING: file already exists: {target}")
+      else:
          with open(target, "w") as f:
             f.write(zlib.decompress(blob).decode())
-      else:
-         print(f"file exists, skipping: {target}")
+         print(f"WRITING: {target}")
 
 def cmd_download(argv):
    Gutenberg().download(argv[0])


### PR DESCRIPTION
**WHAT**

* creates directory named after author
* slugifies author and title
* writes files to disk using [author]/[title]

**EXAMPLE**

Assuming the author `milne`'s books have been downloaded, then they can be persisted to file as:

```
ebooks/gutenberg/text$ gutenberg file author:milne
create directory: milne-alan-alexander
create file: milne-alan-alexander/the-sunny-side
create file: milne-alan-alexander/second-plays
create file: milne-alan-alexander/the-red-house-mystery
create file: milne-alan-alexander/once-a-week
create file: milne-alan-alexander/happy-days
create file: milne-alan-alexander/once-on-a-time
create file: milne-alan-alexander/the-holiday-round
create file: milne-alan-alexander/not-that-it-matters
create file: milne-alan-alexander/three-plays
create file: milne-alan-alexander/a-gallery-of-children
create file: milne-alan-alexander/winnie-the-pooh
create file: milne-alan-alexander/belinda-an-april-folly-in-three-
create file: milne-alan-alexander/when-we-were-very-young
create file: milne-alan-alexander/now-we-are-six
create file: milne-alan-alexander/the-days-play
create file: milne-alan-alexander/the-house-at-pooh-corner
create file: milne-alan-alexander/mr-pim-passes-by-a-comedy-in-thr
create file: milne-alan-alexander/if-i-may
create file: milne-alan-alexander/first-plays
```

Which yields one file per title:

```
ebooks/gutenberg/text$ tree milne-alan-alexander/
milne-alan-alexander/
├── a-gallery-of-children
├── belinda-an-april-folly-in-three-
├── first-plays
├── happy-days
├── if-i-may
├── mr-pim-passes-by-a-comedy-in-thr
├── not-that-it-matters
├── now-we-are-six
├── once-a-week
├── once-on-a-time
├── second-plays
├── the-days-play
├── the-holiday-round
├── the-house-at-pooh-corner
├── the-red-house-mystery
├── the-sunny-side
├── three-plays
├── when-we-were-very-young
└── winnie-the-pooh
```