### PR TITLE
adding download_all and file_exact commands

### DIFF
--- a/extractor.ps1
+++ b/extractor.ps1
@@ -1,4 +1,4 @@
-for ($i=1; $i -le 70000; $i++) {
+for ($i=1; $i -le 80000; $i++) {
 	Write-Host "Extracting book ID $i..."
 	python ..\gutenberg.py file_exact $i
 }

--- a/extractor.ps1
+++ b/extractor.ps1
@@ -1,0 +1,4 @@
+for ($i=1; $i -le 70000; $i++) {
+	Write-Host "Extracting book ID $i..."
+	python ..\gutenberg.py file_exact $i
+}

--- a/gutenberg.py
+++ b/gutenberg.py
@@ -54,7 +54,7 @@ from string import ascii_uppercase
 from email.utils import parsedate
 
 # Default database path.
-DB_PATH = "D:\\.gutenberg"
+DB_PATH = "~/.gutenberg"
 
 # Default number of worker processes for parallel downloads.
 DOWNLOAD_POOL_SIZE = 4
@@ -901,7 +901,7 @@ Search commands:
    search <query>    display metadata of ebooks matching a query
    text <query>      display the contents of downloaded ebooks matching a query
    file <query>      save downloaded ebooks matching the query to disk, as [AUTHOR]/[TITlE].txt 
-   file_exact        save downloaded ebooks to disk, as [AUTHOR]/[TITlE].txt 
+   file_exact        save downloaded ebooks to disk by key, as [key]/[AUTHOR]/[TITlE].txt 
    queries           display a list of submitted download queries
 
 Download commands:


### PR DESCRIPTION
I have added two commands:

download_all: to download all files without query

file_exact: to extract all files from the database without query. 

the commands could have better names, but...

extractor.ps1 was for myself, to extract files from db, I didn't intended to include it in the pull request, so I deleted it from it.